### PR TITLE
Allow authorized users to avoid chemical ban list

### DIFF
--- a/askcos/askcos_site/main/views/retro.py
+++ b/askcos/askcos_site/main/views/retro.py
@@ -18,7 +18,7 @@ from ..globals import RetroTransformer, RETRO_FOOTNOTE, \
 
 from ..utils import ajax_error_wrapper, resolve_smiles
 from .price import price_smiles_func
-from .users import can_control_robot
+from .users import can_control_robot, can_avoid_banned_chemicals
 from ..forms import SmilesInputForm
 from ..models import BlacklistedReactions, BlacklistedChemicals
 
@@ -39,6 +39,13 @@ BANNED_SMILES = [
     ) 
     for smi in BANNED_SMILES
 ]
+
+def is_banned(request, smiles):
+    if can_avoid_banned_chemicals(request):
+        return False
+    if smiles in BANNED_SMILES:
+        return True
+    return False
 
 #@login_required
 def retro(request, smiles=None, chiral=True, mincount=0, max_n=200):
@@ -81,7 +88,7 @@ def retro(request, smiles=None, chiral=True, mincount=0, max_n=200):
             context['err'] = 'Could not parse!'
             return render(request, 'retro.html', context)
 
-    if smiles is not None and smiles not in BANNED_SMILES:
+        if smiles is not None and not is_banned(request, smiles):
 
         # OLD: ALWAYS CHIRAL NOW
         # if 'retro_lit' in request.POST: return redirect('retro_lit_target', smiles=smiles)

--- a/askcos/askcos_site/main/views/retro.py
+++ b/askcos/askcos_site/main/views/retro.py
@@ -88,7 +88,7 @@ def retro(request, smiles=None, chiral=True, mincount=0, max_n=200):
             context['err'] = 'Could not parse!'
             return render(request, 'retro.html', context)
 
-        if smiles is not None and not is_banned(request, smiles):
+    if smiles is not None and not is_banned(request, smiles):
 
         # OLD: ALWAYS CHIRAL NOW
         # if 'retro_lit' in request.POST: return redirect('retro_lit_target', smiles=smiles)

--- a/askcos/askcos_site/main/views/users.py
+++ b/askcos/askcos_site/main/views/users.py
@@ -17,6 +17,9 @@ can_control_robot = lambda request: request.user.get_username() in ['ccoley']
 def can_view_reaxys(request):
     return request.user.is_authenticated and request.user.groups.filter(name='reaxys_view').exists()
 
+def can_avoid_banned_chemicals(request):
+    return request.user.is_authenticated and request.user.groups.filter(name='avoid_banned_chemicals').exists()
+
 def log_this_request(method):
     def f(*args, **kwargs):
         try:


### PR DESCRIPTION
Allow users in `avoid_banned_chemicals` group to avoid the chemical ban list.

Introduces `is_banned(request, smiles)` function to add substructure matching in the future.