### PR TITLE
Update draw.py

### DIFF
--- a/makeit/utilities/io/draw.py
+++ b/makeit/utilities/io/draw.py
@@ -12,6 +12,8 @@ import re
 Many of these functions are taken from RDKit.
 '''
 
+from rdkit.Chem import rdDepictor
+rdDepictor.SetPreferCoordGen(True)
 
 def mols_from_smiles_list(all_smiles):
     '''Given a list of smiles strings, this function creates rdkit


### PR DESCRIPTION
To beauty the image of complex molecule ('CC1CCC2C(C(=O)OC3C24C1CCC(O3)(OO4)C)C')

https://github.com/rdkit/rdkit/issues/2960
```
One solution when the RDKit does a poor job of drawing a molecule is to use the coordgen library from Schrodinger to create the coordinates. This is part of RDKit conda builds and can be enabled as the default algorithm for generating coordinates by doing:

from rdkit.Chem import rdDepictor
rdDepictor.SetPreferCoordGen(True)

```